### PR TITLE
Add: webUi update with `sh run_webui.sh update`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,47 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Breaks
 
 
-## 0.2.0 (2024-02-18)
+## 0.3.0 (2025-07-07)
 ---
 
 ### New
-Abstract and add to the Genericsuite project [GS-141].
+Add documentation to replace exampleapp and other example names to the app specific ones [GS-141].
+Add "webUi" update with sh `run_webui.sh update`.
+
+### Changes
+SECRET_GROUP envvar moved from apply_secrets.sh to .env [GS-141].
+Fix typos, add additional notes, remove hard-coded IDs in various files.
+Change to run "scripts/get_os_name_type.sh" with source or "." in the firewall manager. [GS-141]
+Change to get the latest n8n version in the docker compose file.
+
+
+## 0.2.0 (2025-02-18)
+---
+
+### New
+Abstract and add to the Genericsuite project (from FynApp GitOps project) [GS-141].
 Implement ollama server [GS-139].
 Implement n8n server [GS-165]
+Add WEBHOOK_URL to n8n service to customize the endpoint server base URL.
+
+### Fixes
+"Makefile", "run_n8n.sh", "firewall_manager.sh" and "get_os_name_type.sh" scripts to work on Ubuntu.
+
+
+## 0.1.3 (2024-10-14)
+---
+
+### New
+Add firewall manager [GS-141].
+
+### Changes
+Enhanced webui run with GPU support and opening the web port [GS-139].
+Better version check in docker installer [GS-141].
+NVIDIA container-toolkit install in run_webui [GS-139].
+
+### Fixes
+Fix sudo in the script (not running it) to minikube install and start [GS-141].
+Fix "get_my_ip" and "map_network" linting [GS-141].
 
 
 ## 0.1.2 (2022-03-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 Add documentation to replace exampleapp and other example names to the app specific ones [GS-141].
-Add "webUi" update with sh `run_webui.sh update`.
+Add WebUI update with sh `run_webui.sh update`.
 
 ### Changes
 SECRET_GROUP envvar moved from apply_secrets.sh to .env [GS-141].
@@ -50,9 +50,9 @@ Add WEBHOOK_URL to n8n service to customize the endpoint server base URL.
 Add firewall manager [GS-141].
 
 ### Changes
-Enhanced webui run with GPU support and opening the web port [GS-139].
+Enhanced WebUI run with GPU support and opening the web port [GS-139].
 Better version check in docker installer [GS-141].
-NVIDIA container-toolkit install in run_webui [GS-139].
+NVIDIA container-toolkit install in "run_webui.sh" [GS-139].
 
 ### Fixes
 Fix sudo in the script (not running it) to minikube install and start [GS-141].

--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -47,8 +47,6 @@ services:
 
   n8n:
     image: docker.n8n.io/n8nio/n8n
-    # image: docker.n8n.io/n8nio/n8n:nightly
-    # image: docker.n8n.io/n8nio/n8n:1.76.0
     restart: always
     environment:
       - DB_TYPE=postgresdb

--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -46,9 +46,9 @@ services:
         condition: service_healthy
 
   n8n:
-    # image: docker.n8n.io/n8nio/n8n
+    image: docker.n8n.io/n8nio/n8n
     # image: docker.n8n.io/n8nio/n8n:nightly
-    image: docker.n8n.io/n8nio/n8n:1.76.0
+    # image: docker.n8n.io/n8nio/n8n:1.76.0
     restart: always
     environment:
       - DB_TYPE=postgresdb

--- a/ollama/run_webui.sh
+++ b/ollama/run_webui.sh
@@ -28,16 +28,15 @@ run_webui() {
     docker stop open-webui && docker rm open-webui
     if [ "$RUN_WITH_GPU" = "0" ]; then
         # With NO GPU
-        # docker run -d --network=host -v open-webui:/app/backend/data -e OLLAMA_BASE_URL=http://127.0.0.1:11434 --name open-webui --restart always ghcr.io/open-webui/open-webui:main
-	echo ""
-	echo "Running open-webui with NO GPU"
-	echo ""
+        echo ""
+        echo "Running open-webui with NO GPU"
+        echo ""
         docker run -d -p $WEBUI_PORT:8080 --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
     else
         # With GPU
-	echo ""
-	echo "Running open-webui WITH GPU support..."
-	echo ""
+        echo ""
+        echo "Running open-webui WITH GPU support..."
+        echo ""
         docker run -d -p $WEBUI_PORT:8080 --gpus all --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:cuda
     fi
     echo ""
@@ -134,6 +133,7 @@ if [ "$ACTION" = "install" ]; then
 
         $SUDO_CMD yum install -y nvidia-container-toolkit
     else
+        echo ""
         echo "Linux distro [$OS_TYPE] is not supported"
         exit 1
     fi
@@ -150,17 +150,20 @@ if [ "$ACTION" = "install" ]; then
 
     echo ""
     echo "Restart the Docker daemon"
+    echo ""
 
     $SUDO_CMD systemctl restart docker
 
     echo ""
     echo "Done! NVIDIA container-toolkit install was completed."
+    echo ""
     run_done
 fi
 
 if [ "$ACTION" = "open" ]; then
     echo ""
     echo "Opening public access to port ${WEBUI_PORT} in the firewall"
+    echo ""
     sh ../scripts/firewall_manager.sh open ${WEBUI_PORT}
     run_done
 fi
@@ -168,6 +171,7 @@ fi
 if [ "$ACTION" = "close" ]; then
     echo ""
     echo "Closing public access to port ${WEBUI_PORT} in the firewall"
+    echo ""
     sh ../scripts/firewall_manager.sh close ${WEBUI_PORT}
     run_done
 fi

--- a/ollama/run_webui.sh
+++ b/ollama/run_webui.sh
@@ -7,13 +7,57 @@
 # https://github.com/open-webui/open-webui?tab=readme-ov-file#installation-with-default-configuration
 # https://ntck.co/ep_401
 
+run_done() {
+    echo ""
+    echo "Done!"
+    exit 0
+}
+
+run_help() {
+    echo ""
+    echo "Usage: $0 run|stop|install|update|open|close"
+    echo ""
+    exit 0
+}
+
+run_webui() {
+    # Stop and remove any previous container
+    echo ""
+    echo "Stopping open-webui..."
+    echo ""
+    docker stop open-webui && docker rm open-webui
+    if [ "$RUN_WITH_GPU" = "0" ]; then
+        # With NO GPU
+        # docker run -d --network=host -v open-webui:/app/backend/data -e OLLAMA_BASE_URL=http://127.0.0.1:11434 --name open-webui --restart always ghcr.io/open-webui/open-webui:main
+	echo ""
+	echo "Running open-webui with NO GPU"
+	echo ""
+        docker run -d -p $WEBUI_PORT:8080 --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
+    else
+        # With GPU
+	echo ""
+	echo "Running open-webui WITH GPU support..."
+	echo ""
+        docker run -d -p $WEBUI_PORT:8080 --gpus all --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:cuda
+    fi
+    echo ""
+    docker ps
+    echo ""
+    echo "Wainting 50 seconds"
+    sleep 50
+    echo ""
+    echo "Please check that open-webui container is running..."
+    echo ""
+    docker ps
+}
+
 REPO_BASEDIR="`pwd`"
 cd "`dirname "$0"`"
 SCRIPTS_DIR="`pwd`"
 
 SUDO_CMD=""
 if [ $(whoami) != "root" ] ; then
-	SUDO_CMD="sudo"
+    SUDO_CMD="sudo"
 fi
 
 if [ "$RUN_WITH_GPU" = "" ]; then
@@ -111,38 +155,57 @@ if [ "$ACTION" = "install" ]; then
 
     echo ""
     echo "Done! NVIDIA container-toolkit install was completed."
+    run_done
 fi
 
 if [ "$ACTION" = "open" ]; then
     echo ""
     echo "Opening public access to port ${WEBUI_PORT} in the firewall"
     sh ../scripts/firewall_manager.sh open ${WEBUI_PORT}
+    run_done
 fi
 
 if [ "$ACTION" = "close" ]; then
     echo ""
     echo "Closing public access to port ${WEBUI_PORT} in the firewall"
     sh ../scripts/firewall_manager.sh close ${WEBUI_PORT}
+    run_done
 fi
 
 if [ "$ACTION" = "stop" ]; then
     # Stop and remove any previous container
     docker stop open-webui && docker rm open-webui
     docker ps
+    run_done
 fi
 
 if [ "$ACTION" = "run" ]; then
-    # Stop and remove any previous container
-    docker stop open-webui && docker rm open-webui
-    if [ "$RUN_WITH_GPU" = "0" ]; then
-        # With NO GPU
-        # docker run -d --network=host -v open-webui:/app/backend/data -e OLLAMA_BASE_URL=http://127.0.0.1:11434 --name open-webui --restart always ghcr.io/open-webui/open-webui:main
-        docker run -d -p $WEBUI_PORT:8080 --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
-    else
-        # With GPU
-        docker run -d -p $WEBUI_PORT:8080 --gpus all --add-host=host.docker.internal:host-gateway -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:cuda
-    fi
-    docker ps
-    sleep 50
-    docker ps
+    run_webui
+    run_done
 fi
+
+if [ "$ACTION" = "update" ]; then
+    echo ""
+    echo "Removing existing open-webui container..."
+    echo ""
+    docker rm -f open-webui
+    echo ""
+    echo "Pulling new open-webui docker image version..."
+    echo ""
+    docker pull ghcr.io/open-webui/open-webui:main
+    docker pull ghcr.io/open-webui/open-webui:cuda
+    echo ""
+    echo "Re-running container..."
+    run_webui
+    run_done
+fi
+
+if [ "$ACTION" = "update_wo" ]; then
+    docker run --rm --volume /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --run-once open-webui
+    run_done
+fi
+
+echo ""
+echo "Invalid option: '$ACTION'"
+echo ""
+run_help

--- a/ollama/run_webui.sh
+++ b/ollama/run_webui.sh
@@ -15,7 +15,7 @@ run_done() {
 
 run_help() {
     echo ""
-    echo "Usage: $0 run|stop|install|update|open|close"
+    echo "Usage: $0 run|stop|install|update|update_watchtower|open|close"
     echo ""
     exit 0
 }
@@ -43,7 +43,7 @@ run_webui() {
     echo ""
     docker ps
     echo ""
-    echo "Wainting 50 seconds"
+    echo "Waiting 50 seconds"
     sleep 50
     echo ""
     echo "Please check that open-webui container is running..."
@@ -200,8 +200,13 @@ if [ "$ACTION" = "update" ]; then
     run_done
 fi
 
-if [ "$ACTION" = "update_wo" ]; then
+if [ "$ACTION" = "update_watchtower" ]; then
+    echo ""
+    echo "Updating open-webui container using Watchtower (run-once mode)..."
+    echo ""
     docker run --rm --volume /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --run-once open-webui
+    echo ""
+    docker ps
     run_done
 fi
 


### PR DESCRIPTION
## 0.3.0 (2025-07-07)
---

### New
Add documentation to replace exampleapp and other example names to the app specific ones [GS-141].
Add WebUI update with sh `run_webui.sh update`.

### Changes
SECRET_GROUP envvar moved from apply_secrets.sh to .env [GS-141].
Fix typos, add additional notes, remove hard-coded IDs in various files.
Change to run "scripts/get_os_name_type.sh" with source or "." in the firewall manager. [GS-141]
Change to get the latest n8n version in the docker compose file.


[GS-141]: https://mediabros.atlassian.net/browse/GS-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GS-141]: https://mediabros.atlassian.net/browse/GS-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GS-141]: https://mediabros.atlassian.net/browse/GS-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ